### PR TITLE
Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Please read the CONTRIBUTING guide [here](https://github.com/BttrDrgn/GCN-Transl
 - Run the `.bat` of the game you wish to compile in the `scripts/build` folder if on Windows
 - The output should be in `output` when finished and will be named `{folder name} [U].iso`
 
+## Using Docker
+- The `docker` directory contains a `Dockerfile` and example `docker-compose.yml`
+- Update the `docker-compose.yml` `volumes` section to map your local directories for `isos` and `outputs`. (Ensure all iso files are named correctly)
+- Start the docker container: `docker compose up --build --detach`
+- Translate as many games as you wish, for example: `docker exec gcn-translation ./translate "HomeLand"`
+- Stop the docker container: `docker compose down`
+
 --------------
 
 ### Visual Studio Code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:22.04
+
+# install required packages
+RUN apt update && apt upgrade -y && apt install -y wget git unzip
+
+# clone repo
+RUN git clone --recurse-submodules https://github.com/BttrDrgn/GCN-Translations.git
+
+# download bass
+RUN wget -nv -O /tmp/bass.zip https://github.com/ARM9/bass/releases/download/v18/bass-ubuntu.zip
+RUN unzip -d GCN-Translations/bass /tmp/bass.zip
+RUN rm /tmp/bass.zip
+RUN chmod +x GCN-Translations/bass/bass
+
+#
+# wine, devkitpro and compilers are required for decomp
+# left here for future usage
+#
+
+# install wine
+#RUN dpkg --add-architecture i386
+#RUN mkdir -pm755 /etc/apt/keyrings
+#RUN wget -nv -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+#RUN wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+#RUN apt update && apt upgrade -y
+#RUN apt install -y --install-recommends winehq-stable
+
+# install devkitpro
+#RUN apt install -y build-essential python3
+#RUN wget -nv -O /tmp/install-devkitpro-pacman https://apt.devkitpro.org/install-devkitpro-pacman
+#RUN chmod +x /tmp/install-devkitpro-pacman
+#RUN yes | /tmp/install-devkitpro-pacman && rm /tmp/install-devkitpro-pacman
+#RUN dkp-pacman --noconfirm -S gamecube-dev
+#RUN echo "source /etc/profile.d/devkit-env.sh" >> /root/.bashrc
+
+# download compilers
+#RUN wget -nv -O /tmp/GC_WII_COMPILERS.zip https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip
+#RUN mkdir GCN-Translations/decomp/homeland/tools/mwcc_compiler
+#RUN mkdir /tmp/compilers
+#RUN unzip -d /tmp/compilers /tmp/GC_WII_COMPILERS.zip
+#RUN cp -r /tmp/compilers/GC/* GCN-Translations/decomp/homeland/tools/mwcc_compiler
+#RUN rm /tmp/GC_WII_COMPILERS.zip && rm -r /tmp/compilers
+
+# tidy up
+RUN apt clean
+
+# copy helper command script
+COPY translate .
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ./
       dockerfile: Dockerfile
     container_name: "gcn-translation"
-    image: exptom/gcn-translation
+    image: bttrdrgn/gcn-translation
     volumes:
       - ../isos:/GCN-Translations/isos
       - ../output:/GCN-Translations/output

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  gcn-translation:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    container_name: "gcn-translation"
+    image: exptom/gcn-translation
+    volumes:
+      - ../isos:/GCN-Translations/isos
+      - ../output:/GCN-Translations/output
+    restart: unless-stopped
+    tty: true

--- a/docker/translate
+++ b/docker/translate
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cd /GCN-Translations
+
+# Output command usage
+if [ -z "$1" ]
+then
+     echo "Usage: ./translate \"Name Of Game\""
+     exit 1
+fi
+
+# check provided game exists
+if [ ! -d "games/$1" ]; then
+    echo "Game '$1' does not exist, available choices are:"
+    ls games
+    exit 1
+fi
+
+# update translations git repo
+echo "Updating translations repo..."
+git pull
+
+# build the ISO
+echo "Creating translated ISO for '$1'..."
+bass/bass "games/$1/Main.asm"
+


### PR DESCRIPTION
Added a Dockerfile and helper script as well as an example docker compose config to make it easier to get up and running (especially on Linux/Mac).

I had done quite a bit of work getting the Docker container setup to be able to handle the decomp step (which has now been removed from this repo). I have kept the required decomp setup steps in the Dockerfile but commented them out as they may be useful at a later date and I didn't want to just delete them and have to start again in the future!